### PR TITLE
feat(fixture): add ability to pass fixtures to specs

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ packages:
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
 extra-deps:
-  - squeal-0.5.0.0
+  - squeal-postgresql-0.5.0.0
   - unliftio-pool-0.2.1.0@sha256:4de658feb1b10051c5af024c20cd7baa369c777716c54a7b3e2888a73286aecf
   - records-sop-0.1.0.2
   - tmp-postgres-0.1.1.0                                                                                                


### PR DESCRIPTION
This mimics work done [on Freight](https://github.com/fretlink/freight/blob/development/test/Specs/Fixture.hs), but for a Squeal context.

The general issue with the specs-db patterns are that there are no way to communicate in between fixtures and specs. So, if you create stuff in the fixture, but lack the way to retrieve their ids in the specs (or if it's cumbersome to do so), you're a bit locked. A solution is typically to "pre-decide" the identifiers, but it means that you have to commit to an architecture where caller have the responsability of assigning UUIDs, and you do not necessarily want that (I, for one, don't).

A concrete exemple might help. I could add a test suite in the carrier-directory with the following fixtures (NB: signature and end line are the only one that matters in this example): 

```
fixtures :: ScenarioM m (CarrierUUID, DepotUUID)
fixtures = do
  (carrier1Id, depot1Id, depot2Id) <- basicScenario
  let contact1' = contact1 { depots = [depot1Id, depot2Id] }
  persist $ CreateNewContact contact1'
  pure (carrier1Id, depot1Id)
```

Note that we _return_ a pair of data. Then, provided I have a something that uses our `describeFixtures`, I can write my test in this fashion:

```
specs :: Spec
specs = withScenarioF fixtures "People..." $
    itDBF "Can be found per depots" $ \(c1Id, d1Id) -> do
      fmap length (getDepotPeople d1Id) `shouldReturn` 1
```

Meaning that the `itDBF` test payload receives the parameters returned by the fixture. It helps tremendously when writing tests.

A note on the package.yaml change: squeal changes its package name recently, so I had to keep this up to date. We do not rely on `squeal-commons` in this particular project, because we might want to have it open-source and be less dependant on the fretlink ecosystem.