### PR TITLE
Commit the cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .stack-work/
-squeal-hspec.cabal
 *~

--- a/squeal-hspec.cabal
+++ b/squeal-hspec.cabal
@@ -1,0 +1,64 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 9cdcbd18496e9bcf710b5b8f1b08b1a29e0021262e26fa8dfa77a46ce893d8e0
+
+name:           squeal-hspec
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/githubuser/squeal-hspec#readme>
+homepage:       https://github.com/githubuser/squeal-hspec#readme
+bug-reports:    https://github.com/githubuser/squeal-hspec/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2019 Author name here
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/githubuser/squeal-hspec
+
+library
+  exposed-modules:
+      Squeal.PostgreSQL.Hspec
+  other-modules:
+      Paths_squeal_hspec
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , generics-sop
+    , hspec
+    , monad-control
+    , squeal-postgresql
+    , tmp-postgres
+    , transformers-base
+  default-language: Haskell2010
+
+test-suite squeal-hspec-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_squeal_hspec
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , generics-sop
+    , hspec
+    , monad-control
+    , squeal-hspec
+    , squeal-postgresql
+    , tmp-postgres
+    , transformers-base
+  default-language: Haskell2010


### PR DESCRIPTION
In light of the [recent changes](https://tech.fpcomplete.com/blog/storing-generated-cabal-files) in how `stack` operates, this PR removes the `ignore` rule on the cabal file